### PR TITLE
use config.abooks directly (upstream api change)

### DIFF
--- a/rplugin/python3/deoplete/sources/khard_emails.py
+++ b/rplugin/python3/deoplete/sources/khard_emails.py
@@ -35,12 +35,8 @@ class Source(Base):
 
     def __fill_cache(self):
         khard_config = config.Config()
-        abooks = []
-        for addressbook in khard_config.get_all_address_books():
-            abooks.append(
-                khard_config.get_address_book(addressbook.name, None))
 
-        for vcard in khard.get_contacts(abooks, '', 'name', False, False):
+        for vcard in khard.get_contacts(khard_config.abooks, '', 'name', False, False):
             for type, email_list in vcard.get_email_addresses().items():
                 for email in email_list:
                     self.__cache.append({'word': "{0} <{1}>".format(


### PR DESCRIPTION
`khard.config` has been updated so all address books can be accessed from
the `config.Config().abooks` attribute. The previous functions to access
these have been removed. This change occurred over a few commits in
Jan 2018 (a year ago), and since then v0.13.0 has been released with
these new changes.

This commit breaks compatibility with khard v0.12.2 and below, but
before this commit, it was not compatible with khard v0.13.0.

fixes #1 