### PR TITLE
Initialize the address books

### DIFF
--- a/rplugin/python3/deoplete/sources/khard_emails.py
+++ b/rplugin/python3/deoplete/sources/khard_emails.py
@@ -35,6 +35,7 @@ class Source(Base):
 
     def __fill_cache(self):
         khard_config = config.Config()
+        khard_config.init_address_books()
         for vcard in khard.get_contacts(
                 khard_config.abooks, '', 'name', False, False):
             for type, email_list in vcard.emails.items():


### PR DESCRIPTION
This initializes `abook` in the khard config, which is `None` by default but is later accessed.